### PR TITLE
Fixed missing entitlements in binary

### DIFF
--- a/ipa_sign
+++ b/ipa_sign
@@ -63,10 +63,11 @@ echo "App has provision         '$(/usr/libexec/PlistBuddy -c "Print :Name" mobi
 if [[ ! ($INSPECT_ONLY == 1) ]]; then
     CERTIFICATE="$3"
     security cms -D -i "$PROVISION" > provision.plist
+    /usr/libexec/PlistBuddy  -x -c 'Print :Entitlements' provision.plist > entitlements.plist
     echo "Embedding provision       '$(/usr/libexec/PlistBuddy -c "Print :Name" provision.plist)', which supports '$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" provision.plist)'"
     rm -rf Payload/*.app/_CodeSignature Payload/*.app/CodeResources
     cp "$PROVISION" Payload/*.app/embedded.mobileprovision
-    /usr/bin/codesign -f -s "$CERTIFICATE" --resource-rules Payload/*.app/ResourceRules.plist Payload/*.app
+    /usr/bin/codesign -f -s "$CERTIFICATE" --entitlements entitlements.plist --resource-rules Payload/*.app/ResourceRules.plist Payload/*.app
     zip -qr "$IPA_NEW" Payload
 fi
 [[ $CLEANUP_TEMP -eq 1 ]] && rm -rf "$TMP"


### PR DESCRIPTION
To cut down on possible mistakes, the entitlements of the new
provisioning profile are used.