### PR TITLE
Fix error when inspecting the package.

### DIFF
--- a/ipa_sign
+++ b/ipa_sign
@@ -47,7 +47,6 @@ realpath(){
 }
 
 IPA="$(realpath $1)"
-PROVISION="$(realpath "$2")"
 TMP="$(mktemp -d /tmp/resign.$(basename "$IPA" .ipa).XXXXX)"
 IPA_NEW="$(pwd)/$(basename "$IPA" .ipa).resigned.ipa"
 CLEANUP_TEMP=0 # Do not remove this line or "set -o nounset" will error on checks below
@@ -61,6 +60,7 @@ echo "App has BundleIdentifier  '$(/usr/libexec/PlistBuddy -c 'Print :CFBundleId
 security cms -D -i Payload/*.app/embedded.mobileprovision > mobileprovision.plist
 echo "App has provision         '$(/usr/libexec/PlistBuddy -c "Print :Name" mobileprovision.plist)', which supports '$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" mobileprovision.plist)'"
 if [[ ! ($INSPECT_ONLY == 1) ]]; then
+    PROVISION="$(realpath "$2")"
     CERTIFICATE="$3"
     security cms -D -i "$PROVISION" > provision.plist
     echo "Embedding provision       '$(/usr/libexec/PlistBuddy -c "Print :Name" provision.plist)', which supports '$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" provision.plist)'"


### PR DESCRIPTION
This fixes a command line error that occurs when the"-i" parameter is used.

$ ota-tools/ipa_sign -i Application.ipa
ota-tools/ipa_sign: line 50: $2: unbound variable