### PR TITLE
Stricter error handling. Print path of final resigned ipa.

### DIFF
--- a/ipa_sign
+++ b/ipa_sign
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash 
+set -o errexit
+set -o pipefail
 
 INSPECT_ONLY=0
 if [[ "$1" == '-i' ]]; then
@@ -69,6 +71,7 @@ if [[ ! ($INSPECT_ONLY == 1) ]]; then
     cp "$PROVISION" Payload/*.app/embedded.mobileprovision
     /usr/bin/codesign -f -s "$CERTIFICATE" --entitlements entitlements.plist Payload/*.app
     zip -qr "$IPA_NEW" Payload
+    echo "Resigned IPA saved to $IPA_NEW"
 fi
 if [[ $CLEANUP_TEMP -eq 1 ]]; then
     rm -rf "$TMP"


### PR DESCRIPTION
Thanks for this tool! Now that AirSign is broken it's nice to have something that still works.

I wasted a lot of time today trying to figure out why the install of my resigned IPA wasn't finishing.
I eventually realized that the issue was that I assumed the IPA would be resigned in-place, but it was actually being saved to the working directory.
I added a log message to clarify this.

I also enabled stricter error handling so the script will exit nonzero if a command fails.