### PR TITLE
Correct the path retrieval for provision profile, update version in Info.plist

### DIFF
--- a/ipa_sign
+++ b/ipa_sign
@@ -27,7 +27,7 @@ if [[ ! ( # any of the following are not true
         ) ]];
     then
         cat << EOF >&2
-    Usage: $(basename "$0") Application.ipa foo/bar.mobileprovision "iPhone Distribution: I can haz code signed"
+    Usage: $(basename "$0") Application.ipa foo/bar.mobileprovision "iPhone Distribution: I can haz code signed" 1.1.x
     Usage: $(basename "$0") -i Application.ipa
 
     Options:
@@ -49,6 +49,7 @@ realpath(){
 }
 
 IPA="$(realpath $1)"
+PROVISION="$(realpath "$2")"
 TMP="$(mktemp -d /tmp/resign.$(basename "$IPA" .ipa).XXXXX)"
 IPA_NEW="$(pwd)/$(basename "$IPA" .ipa).resigned.ipa"
 CLEANUP_TEMP=0 # Do not remove this line or "set -o nounset" will error on checks below
@@ -62,9 +63,13 @@ echo "App has BundleIdentifier  '$(/usr/libexec/PlistBuddy -c 'Print :CFBundleId
 security cms -D -i Payload/*.app/embedded.mobileprovision 2>/dev/null > mobileprovision.plist
 echo "App has provision         '$(/usr/libexec/PlistBuddy -c "Print :Name" mobileprovision.plist)', which supports '$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" mobileprovision.plist)'"
 if [[ ! ($INSPECT_ONLY == 1) ]]; then
-    PROVISION="$(realpath "$2")"
+    VERSION="$4"
+    echo "Setting both BundleShortVersionString and BundleVersion to ${VERSION}"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" Info.plist
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${VERSION}" Info.plist
+    plutil -convert binary1 Info.plist -o Payload/*.app/Info.plist
     CERTIFICATE="$3"
-    security cms -D -i "$PROVISION" 2>/dev/null> provision.plist
+    security cms -D -i "$PROVISION" > provision.plist
     /usr/libexec/PlistBuddy  -x -c 'Print :Entitlements' provision.plist > entitlements.plist
     echo "Embedding provision       '$(/usr/libexec/PlistBuddy -c "Print :Name" provision.plist)', which supports '$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" provision.plist)'"
     rm -rf Payload/*.app/_CodeSignature Payload/*.app/CodeResources


### PR DESCRIPTION
* Move `PROVISION` setting to be before `cd` to make value contain correct path to provision profile instead begging with /tmp
* Add 4th parameter for version number to update Bundle Version and Bundle Short Version in Info.plist because, usually, you need to bump the version number of the resigned bundle in order to make users distinguish the updated version from the previous one.